### PR TITLE
prevent window.getSelection() errors and fix typo

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -142,7 +142,7 @@ class TextScanner extends EventDispatcher {
 
         this._enabledValue = value;
 
-        if (value) {
+        if (value && window.getSelection()) {
             this._hookEvents();
             this._userHasNotSelectedAnythingManually = window.getSelection().isCollapsed;
         }

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -117,5 +117,11 @@
         "popup.html",
         "template-renderer.html"
     ],
-    "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
+    "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *",
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "alex@foosoft.net",
+            "strict_min_version": "57.0"
+        }
+    }
 }

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1154,7 +1154,7 @@
                 <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
             </div>
         </div></div>
-        <div class="settings-item settings-item-button advanced-only data-modal-action="show,custom-css"><div class="settings-item-inner">
+        <div class="settings-item settings-item-button advanced-only" data-modal-action="show,custom-css"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Configure custom CSS&hellip;</div>
             </div>


### PR DESCRIPTION
I was getting `TypeError: window.getSelection() is null` originating from each tab I had opened.

The `Configure custom CSS...` option was broken due to a typo.

The `browser_specific_settings` key is [mandatory](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) in Firefox due to it being side-loaded. Chrome still works fine with this extra key added.