### PR TITLE
Fix Firefox card templates CSP issue

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -117,7 +117,7 @@
         "popup.html",
         "template-renderer.html"
     ],
-    "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *",
+    "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *",
     "browser_specific_settings": {
         "gecko": {
             "id": "alex@foosoft.net",


### PR DESCRIPTION
Allows `Anki Card Templates` to work on Firefox.